### PR TITLE
fix: Relative path to the challenge.html file

### DIFF
--- a/2026/index.html
+++ b/2026/index.html
@@ -386,7 +386,7 @@
 						</p> -->
 
 						 <p class="text-center">
-                         All details regarding the challenge can be found <a href="./2026/challenge.html">here</a>.
+                         All details regarding the challenge can be found <a href="./challenge.html">here</a>.
 
 						</p>
 


### PR DESCRIPTION
Currently, the live website has the relative path of the challenge page as `2026/challenge.html` which causes a invalid page  when navigating to the challenge page from `index.html`. 

Don't know which index.html is being used for the live site so changed the one under the 2026 folder for now. 